### PR TITLE
time

### DIFF
--- a/Card-Game/script.js
+++ b/Card-Game/script.js
@@ -216,4 +216,5 @@ function hide_all_cards(){
     show_all_cards();
     setTimeout(hide_all_cards,1000);
     setTimeout(timer,1300);
+
 }


### PR DESCRIPTION
Decreased timeLimit to 20 seconds.
Reduced card reveal time at game start to 0.3s.
Timer interval now 50ms (was 10ms, but real-life effect is much faster). Flipping cards back after a mismatch is now 300ms (was 700ms). Win screen shows after 0.25s (was 0.5s).
Timer and game start both accelerated.