### PR TITLE
feat(repo): Add issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,27 @@
+---
+name: Bug Report
+about: Create a report to help us improve the project
+title: '[BUG] A brief, descriptive title'
+labels: 'bug, needs-triage'
+---
+
+### Describe the Bug
+A clear and concise description of what the bug is.
+
+### To Reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See the error
+
+### Expected Behavior
+A clear and concise description of what you expected to happen.
+
+### Screenshots
+If applicable, add screenshots to help explain your problem.
+
+### Environment (please complete the following information):
+- **OS:** [e.g., Windows 11, Ubuntu 22.04]
+- **Browser (if applicable):** [e.g., Chrome, Firefox]
+- **Version:** [e.g., v1.2.3]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+### Closes: #[issue_number_goes_here]
+
+---
+
+### Description
+A clear and concise description of what this pull request accomplishes.
+
+### Type of Change
+Please delete options that are not relevant.
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Other (please describe):
+
+### How Has This Been Tested?
+Please describe the tests that you ran to verify your changes.
+
+### Checklist:
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas


### PR DESCRIPTION
Closes #493 

## What this PR does
This PR adds standardized templates to the repository to improve the quality and consistency of issues and pull requests, making project maintenance easier.

- A `bug_report.md` issue template has been added to the existing `ISSUE_TEMPLATE` directory.
- A new `PULL_REQUEST_TEMPLATE.md` has been added to the `.github` folder.

## How to verify
1. Click on the "Issues" tab and then "New issue." You should now see "Bug Report" as an option.
2. Start the process of creating a new pull request. The description should be pre-filled with the new PR template.