### PR TITLE
fix(blackjack): Hide dealer's hole card and check for blackjack

### DIFF
--- a/BlackJack/script.js
+++ b/BlackJack/script.js
@@ -40,10 +40,15 @@ function dealCard(player) {
     player.push(card);
 }
 
-function renderHand(playerId, hand) {
+function renderHand(playerId, hand, hideSecondCard = false) {
     const cardsDiv = document.getElementById(playerId + '-cards');
-    cardsDiv.innerHTML = hand.map(card => `<div class="card">${card.value}${suitsSymbols[card.suit]}</div>`).join('');
-    document.getElementById(playerId + '-score').textContent = 'Score: ' + calculateScore(hand);
+    if (hideSecondCard) {
+        cardsDiv.innerHTML = `<div class="card">${hand[0].value}${suitsSymbols[hand[0].suit]}</div><div class="card card-back"></div>`;
+        document.getElementById(playerId + '-score').textContent = 'Score: ' + getCardValue(hand[0]);
+    } else {
+        cardsDiv.innerHTML = hand.map(card => `<div class="card">${card.value}${suitsSymbols[card.suit]}</div>`).join('');
+        document.getElementById(playerId + '-score').textContent = 'Score: ' + calculateScore(hand);
+    }
 }
 
 function startGame() {
@@ -56,28 +61,27 @@ function startGame() {
         dealCard(playerHand);
         dealCard(dealerHand);
     }
-    renderGame();
-    document.getElementById('result').textContent = '';
-}
-
-function renderGame() {
     renderHand('player', playerHand);
-    renderHand('dealer', dealerHand);
+    renderHand('dealer', dealerHand, true);
+    document.getElementById('result').textContent = '';
 
-    const playerScore = calculateScore(playerHand);
-    if (playerScore > 21) {
-        endGame('You busted! Dealer wins.');
+    if (calculateScore(playerHand) === 21) {
+        endGame('Blackjack! You win!');
     }
 }
 
 function hit() {
     if (isGameOver) return;
     dealCard(playerHand);
-    renderGame();
+    renderHand('player', playerHand);
+    if (calculateScore(playerHand) > 21) {
+        endGame('You busted! Dealer wins.');
+    }
 }
 
 function stand() {
     if (isGameOver) return;
+    renderHand('dealer', dealerHand);
     const dealerPlay = setInterval(() => {
         if (calculateScore(dealerHand) < 17) {
             dealCard(dealerHand);
@@ -104,6 +108,7 @@ function checkWinner() {
 
 function endGame(message) {
     isGameOver = true;
+    renderHand('dealer', dealerHand);
     document.getElementById('result').textContent = message;
 }
 

--- a/BlackJack/style.css
+++ b/BlackJack/style.css
@@ -55,3 +55,8 @@ button:hover {
     text-align: center;
     user-select: none;
 }
+
+.card-back {
+    background-color: #5a0000;
+}
+


### PR DESCRIPTION
## 🎮 Fix: Hide Dealer's Hole Card and Add Blackjack Check

### 📌 Summary
This PR fixes a major issue in the Blackjack game where the **dealer's hole card** (second card) was visible at the start of the game.  
It also introduces a **blackjack check** for the player immediately after the initial deal.

---

### 🧩 Changes Introduced
- 🔒 The dealer’s **second card** is now hidden until the player stands.  
- 👀 The dealer’s **score** is only partially displayed until their turn.  
- 🃏 Added logic to **check for player blackjack** right after dealing.  
- 🎨 Added a new `.card-back` CSS class to visually represent the hidden card.  
- 🧠 Improved overall game flow to match standard Blackjack rules.  

---

### 🧪 How to Test
1. Start a new round in the Blackjack game.  
2. Observe that the **dealer’s second card** appears hidden (face down).  
3. If the player has **21 on the deal**, the game should automatically declare a **blackjack**.  
4. After the player stands, the dealer’s hidden card should flip and display correctly.  

---

### 🧱 Additional Notes
- This fix improves game realism and rule accuracy.  
- Tested for multiple rounds and edge cases.  
- No dependencies added or removed.  

---

### ✅ Checklist
- [x] Dealer’s hole card hidden until player stands  
- [x] Player blackjack check implemented  
- [x] `.card-back` styling verified  
- [x] No visual or logic regressions found  

---

🩷 **This PR is submitted as part of Hacktoberfest 2025!**
